### PR TITLE
Add cron controller and token for Meilisearch sync

### DIFF
--- a/controllers/front/cron.php
+++ b/controllers/front/cron.php
@@ -1,0 +1,178 @@
+<?php
+
+class MeilisearchprestashopCronModuleFrontController extends ModuleFrontController
+{
+    public function __construct()
+	{
+		parent::__construct();
+	}
+    public function postProcess()
+    {
+
+        $token = Tools::getValue('token');
+        if(!$token == Configuration::get('MEILISEARCHPRESTASHOP_TOKEN_CRON'))
+        {
+            PrestaShopLogger::addLog($this->l('Illegal access to CRON Meilisearch'), 3);
+            Tools::redirect('404');
+            exit;
+        }
+        
+        if(Tools::getValue('action') == 'indexProducts'){
+            $success = $this->indexProductsAction();
+        }
+
+        if($success){
+            exit(http_response_code(200));
+        }else {
+            exit(http_response_code(400));
+        }
+
+    }
+
+    public function indexProductsAction()
+    {
+
+        $languages = Language::getLanguages();
+        
+        foreach ($languages as $language) {
+            $id_lang = $language['id_lang'];
+            $iso_code = $language['iso_code'];
+            $meiliUrl = Configuration::get('MEILISEARCHPRESTASHOP_URL');
+    
+    
+            $sql = '
+                SELECT p.*, product_shop.*, pl.*, 
+                    m.`name` AS manufacturer_name, 
+                    s.`name` AS supplier_name
+                FROM `' . _DB_PREFIX_ . 'product` p
+                ' . Shop::addSqlAssociation('product', 'p') . '
+                LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl 
+                    ON (p.`id_product` = pl.`id_product` ' . Shop::addSqlRestrictionOnLang('pl') . ')
+                LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m 
+                    ON (m.`id_manufacturer` = p.`id_manufacturer`)
+                LEFT JOIN `' . _DB_PREFIX_ . 'supplier` s 
+                    ON (s.`id_supplier` = p.`id_supplier`)
+                WHERE pl.`id_lang` = ' . (int) $id_lang . '
+                AND product_shop.`active` = 1
+            ';
+    
+            $products = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+    
+            
+            $typeMap = [
+                'id_product' => 'int',
+                'id_supplier' => 'int',
+                'id_manufacturer' => 'int',
+                'id_category_default' => 'int',
+                'id_shop_default' => 'int',
+                'id_tax_rules_group' => 'int',
+                'on_sale' => 'bool',
+                'online_only' => 'bool',
+                'low_stock_alert' => 'bool',
+                'quantity' => 'int',
+                'minimal_quantity' => 'int',
+                'price' => 'float',
+                'wholesale_price' => 'float',
+                'unit_price_ratio' => 'float',
+                'additional_shipping_cost' => 'float',
+                'width' => 'float',
+                'height' => 'float',
+                'depth' => 'float',
+                'weight' => 'float',
+                'out_of_stock' => 'int',
+                'additional_delivery_times' => 'bool',
+                'quantity_discount' => 'bool',
+                'customizable' => 'bool',
+                'uploadable_files' => 'bool',
+                'text_fields' => 'bool',
+                'active' => 'bool',
+                'id_type_redirected' => 'int',
+                'available_for_order' => 'bool',
+                'show_condition' => 'bool',
+                'show_price' => 'bool',
+                'indexed' => 'bool',
+                'cache_is_pack' => 'bool',
+                'cache_has_attachments' => 'bool',
+                'is_virtual' => 'bool',
+                'cache_default_attribute' => 'int',
+                'advanced_stock_management' => 'bool',
+                'pack_stock_type' => 'int',
+                'state' => 'int',
+                'atoosync' => 'bool',
+                'id_shop' => 'int',
+                'final_price' => 'float',
+                'id_lang' => 'int',
+            ];
+    
+            // Récupère les IDs produits
+            $productIds = array_column($products, 'id_product');
+            $productIdsStr = implode(',', array_map('intval', $productIds));
+    
+            // Récupération des features
+            $featuresSql = '
+                SELECT id_product, id_feature, id_feature_value
+                FROM `'._DB_PREFIX_.'feature_product`
+                WHERE id_product IN (' . $productIdsStr . ')
+            ';
+    
+            $featureResults = Db::getInstance()->executeS($featuresSql);
+    
+            // Structure à plat : [id_product => [ "2-36", "2-60", ... ]]
+            $productFeatureValues = [];
+            foreach ($featureResults as $row) {
+                $idProduct = (int)$row['id_product'];
+                $featureKey = (int)$row['id_feature'] . '-' . (int)$row['id_feature_value'];
+    
+                if (!isset($productFeatureValues[$idProduct])) {
+                    $productFeatureValues[$idProduct] = [];
+                }
+    
+                $productFeatureValues[$idProduct][] = $featureKey;
+            }
+            
+            foreach ($products as &$product) {
+                foreach ($typeMap as $field => $type) {
+                    if (array_key_exists($field, $product) && $product[$field] !== null) {
+                        switch ($type) {
+                            case 'int':
+                                $product[$field] = (int) $product[$field];
+                                break;
+                            case 'float':
+                                $product[$field] = (float) $product[$field];
+                                break;
+                            case 'bool':
+                                $product[$field] = (bool) $product[$field];
+                                break;
+                        }
+                    }
+                }
+                $id = $product['id_product'];
+                $product['feature_values'] = $productFeatureValues[$id] ?? [];
+            }
+            unset($product);
+    
+    
+            $payloadIndex = json_encode([
+                'uid' => Configuration::get('MEILISEARCHPRESTASHOP_PREFIX') . 'products_' . $iso_code,
+                'primaryKey' => 'id_product'
+            ]);
+            $this->module->requestCurl($meiliUrl . 'indexes', $payloadIndex);
+    
+            $arrayProductsChunk = array_chunk($products, 200);
+    
+            // Envoi à Meilisearch
+            foreach ($arrayProductsChunk as $arrayProducts) {
+                $this->module->requestCurl($meiliUrl . 'indexes/'. Configuration::get('MEILISEARCHPRESTASHOP_PREFIX') .'products_'.$iso_code.'/documents', json_encode($arrayProducts));
+            }
+    
+            $this->module->requestCurl($meiliUrl . 'indexes/'. Configuration::get('MEILISEARCHPRESTASHOP_PREFIX') .'products_'.$iso_code.'/settings/sortable-attributes', json_encode(['name','price']), 'PUT');
+            $this->module->requestCurl($meiliUrl . 'indexes/'. Configuration::get('MEILISEARCHPRESTASHOP_PREFIX') .'products_'.$iso_code.'/settings/ranking-rules', json_encode(["sort","words","typo","proximity","attribute","exactness"]), 'PUT');
+            $this->module->requestCurl($meiliUrl . 'indexes/'. Configuration::get('MEILISEARCHPRESTASHOP_PREFIX') .'products_'.$iso_code.'/settings/filterable-attributes', json_encode(['id_manufacturer', 'out_of_stock', 'condition', 'id_category_default
+    ', 'quantity', 'feature_values','visibility', 'available_for_order']), 'PUT');
+        }
+
+
+
+        return true;
+    }
+}

--- a/meilisearchprestashop.php
+++ b/meilisearchprestashop.php
@@ -46,7 +46,7 @@ class Meilisearchprestashop extends Module
     {
         $this->name = 'meilisearchprestashop';
         $this->tab = 'search_filter';
-        $this->version = '1.1.1';
+        $this->version = '1.1.2';
         $this->author = 'Doudeau Adam, Johan Vivien';
         $this->need_instance = 0;
 
@@ -247,6 +247,13 @@ class Meilisearchprestashop extends Module
                         'name' => 'MEILISEARCHPRESTASHOP_PREFIX',
                         'label' => $this->l('PREFIX'),
                     ),
+                    array(
+                        'col' => 3,
+                        'type' => 'text',
+                        'name' => 'MEILISEARCHPRESTASHOP_TOKEN_CRON',
+                        'desc' => $this->l('Enter a private key, for exemple').' : ' .Tools::passwdGen(32),
+                        'label' => $this->l('Token for access to the cron'),
+                    ),
                 ),
                 'submit' => array(
                     'title' => $this->l('Save'),
@@ -267,6 +274,7 @@ class Meilisearchprestashop extends Module
             'MEILISEARCHPRESTASHOP_URL' => Configuration::get('MEILISEARCHPRESTASHOP_URL', null),
             'MEILISEARCHPRESTASHOP_KEY' => Configuration::get('MEILISEARCHPRESTASHOP_KEY', null),
             'MEILISEARCHPRESTASHOP_PREFIX' => Configuration::get('MEILISEARCHPRESTASHOP_PREFIX', null),
+            'MEILISEARCHPRESTASHOP_TOKEN_CRON' => Configuration::get('MEILISEARCHPRESTASHOP_TOKEN_CRON', null)
         );
     }
 

--- a/views/js/front/search.js
+++ b/views/js/front/search.js
@@ -22,12 +22,23 @@ function ajaxProductClick(product, index) {
 }
 
 let listProducts = document.getElementById('products');
+
 listProducts.addEventListener('click', function(event) {
-    event.preventDefault();
+    const tag = event.target.tagName.toLowerCase();
+    if (['input', 'button', 'select', 'textarea', 'label'].includes(tag)) {
+        return;
+    }
+
+    if (event.target.closest('.add-to-cart')) {
+        return;
+    }
+
     if (event.target && event.target.closest('.thumbnail-container')) {
+        event.preventDefault();
 
         let product = event.target.closest('.product').firstElementChild;
         let productsRow = document.querySelector('#js-product-list');
+
         ajaxProductClick(product, Array.from(productsRow.firstElementChild.children).indexOf(product.parentElement));
 
         let productHref = product.firstElementChild.firstElementChild.firstElementChild;
@@ -45,6 +56,5 @@ listProducts.addEventListener('click', function(event) {
 
         document.body.appendChild(form);
         form.submit();
-
     }
 });


### PR DESCRIPTION
Introduces a new front controller for cron-based product indexing to Meilisearch, secured by a configurable token. Updates module configuration to include the cron token field and version bump. Improves product list click handling in search.js to avoid interfering with form controls and add-to-cart actions.